### PR TITLE
Enhancement: Change tolerance from absolute to relative

### DIFF
--- a/src/samplics/sae/eblup_area_model.py
+++ b/src/samplics/sae/eblup_area_model.py
@@ -262,7 +262,7 @@ class EblupAreaModel:
                 b_const=b_const,
             )
             sigma2_v += deriv_sigma / info_sigma
-            tolerance = abs(sigma2_v - sigma2_v_previous)
+            tolerance = abs((sigma2_v - sigma2_v_previous)/sigma2_v_previous)
             iterations += 1
 
         return float(max(sigma2_v, 0)), 1 / info_sigma, iterations, tolerance, tolerance <= tol
@@ -375,7 +375,7 @@ class EblupAreaModel:
         re_std_start: float = 0.001,
         b_const: Union[np.ndarray, Number] = 1.0,
         intercept: bool = True,
-        tol: float = 1e-8,
+        tol: float = 1e-4,
         maxiter: int = 100,
     ) -> None:
         """Fits the linear mixed models to estimate the fixed effects and the standard error of


### PR DESCRIPTION
In the EBLUP area model, the convergence tolerance or precision is currently calculated as an absolute difference. This is sensitive to scale. Calculating tolerance as a relative difference accounts for scale. This also allows users to specify a precision level that is not sensitive to the scale of their inputs.

This is also consistent with how the R package, sae, computes tolerance. 
https://github.com/cran/sae/blob/master/R/eblupFH.R#L64

I also changed the default tolerance to match the value in the function documentation.